### PR TITLE
Add support for query options

### DIFF
--- a/customer.go
+++ b/customer.go
@@ -10,7 +10,8 @@ const customersBasePath = "admin/customers"
 // of the Shopify API.
 // See: https://help.shopify.com/api/reference/customer
 type CustomerService interface {
-	Count() (int, error)
+	List(options interface{}) ([]Customer, error)
+	Count(options interface{}) (int, error)
 }
 
 // CustomerServiceOp handles communication with the product related methods of
@@ -19,24 +20,34 @@ type CustomerServiceOp struct {
 	client *Client
 }
 
-type customerCountRoot struct {
-	Count int `json:"count"`
+// Customer represents a Shopify customer
+type Customer struct {
+	ID        int    `json:"id"`
+	Email     string `json:"email"`
+	FirstName string `json:"first_name"`
+	LastName  string `json:"last_name"`
+}
+
+// Represents the result from the customers/X.json endpoint
+type CustomerResource struct {
+	Customer *Customer `json:"customer"`
+}
+
+// Represents the result from the customers.json endpoint
+type CustomersResource struct {
+	Customers []Customer `json:"customers"`
+}
+
+// List customers
+func (s *CustomerServiceOp) List(options interface{}) ([]Customer, error) {
+	path := fmt.Sprintf("%s.json", customersBasePath)
+	resource := new(CustomersResource)
+	err := s.client.Get(path, resource, options)
+	return resource.Customers, err
 }
 
 // Count customers
-func (s *CustomerServiceOp) Count() (int, error) {
+func (s *CustomerServiceOp) Count(options interface{}) (int, error) {
 	path := fmt.Sprintf("%s/count.json", customersBasePath)
-
-	req, err := s.client.NewRequest("GET", path, nil)
-	if err != nil {
-		return 0, err
-	}
-
-	root := new(customerCountRoot)
-	err = s.client.Do(req, root)
-	if err != nil {
-		return 0, err
-	}
-
-	return root.Count, err
+	return s.client.Count(path, options)
 }

--- a/customer_test.go
+++ b/customer_test.go
@@ -1,10 +1,30 @@
 package goshopify
 
 import (
+	"reflect"
 	"testing"
+	"time"
 
 	"github.com/jarcoal/httpmock"
 )
+
+func TestCustomerList(t *testing.T) {
+	setup()
+	defer teardown()
+
+	httpmock.RegisterResponder("GET", "https://fooshop.myshopify.com/admin/customers.json",
+		httpmock.NewStringResponder(200, `{"customers": [{"id":1},{"id":2}]}`))
+
+	customers, err := client.Customer.List(nil)
+	if err != nil {
+		t.Errorf("Customer.List returned error: %v", err)
+	}
+
+	expected := []Customer{{ID: 1}, {ID: 2}}
+	if !reflect.DeepEqual(customers, expected) {
+		t.Errorf("Customer.List returned %+v, expected %+v", customers, expected)
+	}
+}
 
 func TestCustomerCount(t *testing.T) {
 	setup()
@@ -13,12 +33,26 @@ func TestCustomerCount(t *testing.T) {
 	httpmock.RegisterResponder("GET", "https://fooshop.myshopify.com/admin/customers/count.json",
 		httpmock.NewStringResponder(200, `{"count": 5}`))
 
-	cnt, err := client.Customer.Count()
+	httpmock.RegisterResponder("GET", "https://fooshop.myshopify.com/admin/customers/count.json?created_at_min=2016-01-01T00%3A00%3A00Z",
+		httpmock.NewStringResponder(200, `{"count": 2}`))
+
+	cnt, err := client.Customer.Count(nil)
 	if err != nil {
 		t.Errorf("Customer.Count returned error: %v", err)
 	}
 
 	expected := 5
+	if cnt != expected {
+		t.Errorf("Customer.Count returned %d, expected %d", cnt, expected)
+	}
+
+	date := time.Date(2016, time.January, 1, 0, 0, 0, 0, time.UTC)
+	cnt, err = client.Customer.Count(CountOptions{CreatedAtMin: date})
+	if err != nil {
+		t.Errorf("Customer.Count returned error: %v", err)
+	}
+
+	expected = 2
 	if cnt != expected {
 		t.Errorf("Customer.Count returned %d, expected %d", cnt, expected)
 	}

--- a/oauth.go
+++ b/oauth.go
@@ -39,7 +39,7 @@ func (app App) GetAccessToken(shopName string, code string) (string, error) {
 	}
 
 	client := NewClient(app, shopName, "")
-	req, err := client.NewRequest("POST", "admin/oauth/access_token", data)
+	req, err := client.NewRequest("POST", "admin/oauth/access_token", data, nil)
 
 	token := new(Token)
 	err = client.Do(req, token)

--- a/order_test.go
+++ b/order_test.go
@@ -1,10 +1,44 @@
 package goshopify
 
 import (
+	"reflect"
 	"testing"
+	"time"
 
 	"github.com/jarcoal/httpmock"
+	"github.com/shopspring/decimal"
 )
+
+func TestOrderList(t *testing.T) {
+	setup()
+	defer teardown()
+
+	httpmock.RegisterResponder("GET", "https://fooshop.myshopify.com/admin/orders.json",
+		httpmock.NewStringResponder(200, `{"orders": [{"id":1, "total_price": "9.99"},{"id":2}]}`))
+
+	orders, err := client.Order.List(nil)
+	if err != nil {
+		t.Errorf("Order.List returned error: %v", err)
+	}
+
+	expected := []Order{{ID: 1, Total: decimal.NewFromFloat(9.99)}, {ID: 2}}
+	if !reflect.DeepEqual(orders, expected) {
+		t.Errorf("Order.List returned %+v, expected %+v", orders, expected)
+	}
+
+	httpmock.RegisterResponder("GET", "https://fooshop.myshopify.com/admin/orders.json?since_id=1",
+		httpmock.NewStringResponder(200, `{"orders": [{"id":2}]}`))
+
+	orders, err = client.Order.List(ListOptions{SinceID: 1})
+	if err != nil {
+		t.Errorf("Order.List returned error: %v", err)
+	}
+
+	expected = []Order{{ID: 2}}
+	if !reflect.DeepEqual(orders, expected) {
+		t.Errorf("Order.List returned %+v, expected %+v", orders, expected)
+	}
+}
 
 func TestOrderCount(t *testing.T) {
 	setup()
@@ -13,12 +47,26 @@ func TestOrderCount(t *testing.T) {
 	httpmock.RegisterResponder("GET", "https://fooshop.myshopify.com/admin/orders/count.json",
 		httpmock.NewStringResponder(200, `{"count": 7}`))
 
-	cnt, err := client.Order.Count()
+	httpmock.RegisterResponder("GET", "https://fooshop.myshopify.com/admin/orders/count.json?created_at_min=2016-01-01T00%3A00%3A00Z",
+		httpmock.NewStringResponder(200, `{"count": 2}`))
+
+	cnt, err := client.Order.Count(nil)
 	if err != nil {
 		t.Errorf("Order.Count returned error: %v", err)
 	}
 
 	expected := 7
+	if cnt != expected {
+		t.Errorf("Order.Count returned %d, expected %d", cnt, expected)
+	}
+
+	date := time.Date(2016, time.January, 1, 0, 0, 0, 0, time.UTC)
+	cnt, err = client.Order.Count(CountOptions{CreatedAtMin: date})
+	if err != nil {
+		t.Errorf("Order.Count returned error: %v", err)
+	}
+
+	expected = 2
 	if cnt != expected {
 		t.Errorf("Order.Count returned %d, expected %d", cnt, expected)
 	}

--- a/product.go
+++ b/product.go
@@ -10,8 +10,8 @@ const productsBasePath = "admin/products"
 // of the Shopify API.
 // See: https://help.shopify.com/api/reference/product
 type ProductService interface {
-	List() ([]Product, error)
-	Count() (int, error)
+	List(options interface{}) ([]Product, error)
+	Count(options interface{}) (int, error)
 	Get(int) (*Product, error)
 }
 
@@ -27,68 +27,34 @@ type Product struct {
 	Title string `json:"title"`
 }
 
-// productRoot represents a product root
-type productRoot struct {
+// Represents the result from the products/X.json endpoint
+type ProductResource struct {
 	Product *Product `json:"product"`
 }
 
-type productsRoot struct {
+// Represents the result from the products.json endpoint
+type ProductsResource struct {
 	Products []Product `json:"products"`
 }
 
-type productCountRoot struct {
-	Count int `json:"count"`
-}
-
-// Performs a list request given a path
-func (s *ProductServiceOp) List() ([]Product, error) {
+// List products
+func (s *ProductServiceOp) List(options interface{}) ([]Product, error) {
 	path := fmt.Sprintf("%s.json", productsBasePath)
-	req, err := s.client.NewRequest("GET", path, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	root := new(productsRoot)
-	err = s.client.Do(req, root)
-	if err != nil {
-		return nil, err
-	}
-
-	return root.Products, err
+	resource := new(ProductsResource)
+	err := s.client.Get(path, resource, options)
+	return resource.Products, err
 }
 
 // Count products
-func (s *ProductServiceOp) Count() (int, error) {
+func (s *ProductServiceOp) Count(options interface{}) (int, error) {
 	path := fmt.Sprintf("%s/count.json", productsBasePath)
-
-	req, err := s.client.NewRequest("GET", path, nil)
-	if err != nil {
-		return 0, err
-	}
-
-	root := new(productCountRoot)
-	err = s.client.Do(req, root)
-	if err != nil {
-		return 0, err
-	}
-
-	return root.Count, err
+	return s.client.Count(path, options)
 }
 
 // Get individual product
 func (s *ProductServiceOp) Get(productID int) (*Product, error) {
 	path := fmt.Sprintf("%s/%d.json", productsBasePath, productID)
-
-	req, err := s.client.NewRequest("GET", path, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	root := new(productRoot)
-	err = s.client.Do(req, root)
-	if err != nil {
-		return nil, err
-	}
-
-	return root.Product, err
+	resource := new(ProductResource)
+	err := s.client.Get(path, resource, nil)
+	return resource.Product, err
 }

--- a/product_test.go
+++ b/product_test.go
@@ -3,6 +3,7 @@ package goshopify
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/jarcoal/httpmock"
 )
@@ -14,7 +15,7 @@ func TestProductList(t *testing.T) {
 	httpmock.RegisterResponder("GET", "https://fooshop.myshopify.com/admin/products.json",
 		httpmock.NewStringResponder(200, `{"products": [{"id":1},{"id":2}]}`))
 
-	products, err := client.Product.List()
+	products, err := client.Product.List(nil)
 	if err != nil {
 		t.Errorf("Product.List returned error: %v", err)
 	}
@@ -32,12 +33,26 @@ func TestProductCount(t *testing.T) {
 	httpmock.RegisterResponder("GET", "https://fooshop.myshopify.com/admin/products/count.json",
 		httpmock.NewStringResponder(200, `{"count": 3}`))
 
-	cnt, err := client.Product.Count()
+	httpmock.RegisterResponder("GET", "https://fooshop.myshopify.com/admin/products/count.json?created_at_min=2016-01-01T00%3A00%3A00Z",
+		httpmock.NewStringResponder(200, `{"count": 2}`))
+
+	cnt, err := client.Product.Count(nil)
 	if err != nil {
 		t.Errorf("Product.Count returned error: %v", err)
 	}
 
 	expected := 3
+	if cnt != expected {
+		t.Errorf("Product.Count returned %d, expected %d", cnt, expected)
+	}
+
+	date := time.Date(2016, time.January, 1, 0, 0, 0, 0, time.UTC)
+	cnt, err = client.Product.Count(CountOptions{CreatedAtMin: date})
+	if err != nil {
+		t.Errorf("Product.Count returned error: %v", err)
+	}
+
+	expected = 2
 	if cnt != expected {
 		t.Errorf("Product.Count returned %d, expected %d", cnt, expected)
 	}


### PR DESCRIPTION
This commit adds support for query options when performing requests. As
a bonus, both the Customer and Order services now have a List function.

Changes:
- Add query options to client requests.
- Generalize Count functionality
- Generalize Get request functionality
- Add List functions to customers and orders
