### PR TITLE
Move defer to avoid panic when err is not nil

### DIFF
--- a/goshopify.go
+++ b/goshopify.go
@@ -144,11 +144,10 @@ func NewClient(app App, shopName string, token string) *Client {
 // interface instance.
 func (c *Client) Do(req *http.Request, v interface{}) error {
 	resp, err := c.client.Do(req)
-	defer resp.Body.Close()
-
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	err = CheckResponseError(resp)
 	if err != nil {


### PR DESCRIPTION
Noob mistake I guess. I was seeing random Panics at the `defer resp.Body.Close` line and was put on the right track by [this SO answer](http://stackoverflow.com/a/16280362). Having the defer after the error check is also the [officially documented way](https://golang.org/pkg/net/http/)
