### PR TITLE
Added Taxes Included to Order Structure

### DIFF
--- a/order.go
+++ b/order.go
@@ -59,6 +59,7 @@ type Order struct {
 	SubtotalPrice         *decimal.Decimal `json:"subtotal_price"`
 	TotalDiscounts        *decimal.Decimal `json:"total_discounts"`
 	TotalLineItemsPrice   *decimal.Decimal `json:"total_line_items_price"`
+	TaxesIncluded         bool             `json:"taxes_included"`
 	TotalTax              *decimal.Decimal `json:"total_tax"`
 	TotalWeight           int              `json:"total_weight"`
 	FinancialStatus       string           `json:"financial_status"`


### PR DESCRIPTION
- The orders/#.json endpoint has this field, but the Order structure doesn't

This field is needed because the endpoint has it and the Order structure doesn't. It doesn't seem possible to infer that the taxes are included in an order by looking at the TotalTaxes field. 