### PR TITLE
Expose the http.Client

### DIFF
--- a/goshopify.go
+++ b/goshopify.go
@@ -33,7 +33,7 @@ type App struct {
 // Client manages communication with the Shopify API.
 type Client struct {
 	// HTTP client used to communicate with the DO API.
-	client *http.Client
+	Client *http.Client
 
 	// App settings
 	app App
@@ -146,7 +146,7 @@ func NewClient(app App, shopName, token string) *Client {
 
 	baseURL, _ := url.Parse(ShopBaseUrl(shopName))
 
-	c := &Client{client: httpClient, app: app, baseURL: baseURL, token: token}
+	c := &Client{Client: httpClient, app: app, baseURL: baseURL, token: token}
 	c.Product = &ProductServiceOp{client: c}
 	c.Customer = &CustomerServiceOp{client: c}
 	c.Order = &OrderServiceOp{client: c}
@@ -161,7 +161,7 @@ func NewClient(app App, shopName, token string) *Client {
 // response. It does not make much sense to call Do without a prepared
 // interface instance.
 func (c *Client) Do(req *http.Request, v interface{}) error {
-	resp, err := c.client.Do(req)
+	resp, err := c.Client.Do(req)
 	if err != nil {
 		return err
 	}

--- a/goshopify_test.go
+++ b/goshopify_test.go
@@ -46,23 +46,23 @@ func loadFixture(filename string) []byte {
 }
 
 func TestNewClient(t *testing.T) {
-	c := NewClient(app, "fooshop", "abcd")
+	testClient := NewClient(app, "fooshop", "abcd")
 	expected := "https://fooshop.myshopify.com"
-	if c.baseURL.String() != expected {
-		t.Errorf("NewClient BaseURL = %v, expected %v", c.baseURL.String(), expected)
+	if testClient.baseURL.String() != expected {
+		t.Errorf("NewClient BaseURL = %v, expected %v", testClient.baseURL.String(), expected)
 	}
 }
 
 func TestNewClientWithNoToken(t *testing.T) {
-	c := NewClient(app, "fooshop", "")
+	testClient := NewClient(app, "fooshop", "")
 	expected := "https://fooshop.myshopify.com"
-	if c.baseURL.String() != expected {
-		t.Errorf("NewClient BaseURL = %v, expected %v", c.baseURL.String(), expected)
+	if testClient.baseURL.String() != expected {
+		t.Errorf("NewClient BaseURL = %v, expected %v", testClient.baseURL.String(), expected)
 	}
 }
 
 func TestNewRequest(t *testing.T) {
-	c := NewClient(app, "fooshop", "abcd")
+	testClient := NewClient(app, "fooshop", "abcd")
 
 	inURL, outURL := "foo?page=1", "https://fooshop.myshopify.com/foo?limit=10&page=1"
 	inBody := struct {
@@ -74,7 +74,7 @@ func TestNewRequest(t *testing.T) {
 		Limit int `url:"limit"`
 	}
 
-	req, err := c.NewRequest("GET", inURL, inBody, extraOptions{Limit: 10})
+	req, err := testClient.NewRequest("GET", inURL, inBody, extraOptions{Limit: 10})
 	if err != nil {
 		t.Fatalf("NewRequest(%v) err = %v, expected nil", inURL, err)
 	}
@@ -105,7 +105,7 @@ func TestNewRequest(t *testing.T) {
 }
 
 func TestNewRequestForPrivateApp(t *testing.T) {
-	c := NewClient(app, "fooshop", "")
+	testClient := NewClient(app, "fooshop", "")
 
 	inURL, outURL := "foo?page=1", "https://fooshop.myshopify.com/foo?limit=10&page=1"
 	inBody := struct {
@@ -117,7 +117,7 @@ func TestNewRequestForPrivateApp(t *testing.T) {
 		Limit int `url:"limit"`
 	}
 
-	req, err := c.NewRequest("GET", inURL, inBody, extraOptions{Limit: 10})
+	req, err := testClient.NewRequest("GET", inURL, inBody, extraOptions{Limit: 10})
 	if err != nil {
 		t.Fatalf("NewRequest(%v) err = %v, expected nil", inURL, err)
 	}
@@ -162,9 +162,9 @@ func TestNewRequestForPrivateApp(t *testing.T) {
 }
 
 func TestNewRequestMissingToken(t *testing.T) {
-	c := NewClient(app, "fooshop", "")
+	testClient := NewClient(app, "fooshop", "")
 
-	req, _ := c.NewRequest("GET", "/foo", nil, nil)
+	req, _ := testClient.NewRequest("GET", "/foo", nil, nil)
 
 	// Test token is not attached to the request
 	token := req.Header["X-Shopify-Access-Token"]
@@ -174,7 +174,7 @@ func TestNewRequestMissingToken(t *testing.T) {
 }
 
 func TestNewRequestError(t *testing.T) {
-	client := NewClient(app, "fooshop", "abcd")
+	testClient := NewClient(app, "fooshop", "abcd")
 
 	cases := []struct {
 		method  string
@@ -189,7 +189,7 @@ func TestNewRequestError(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		_, err := client.NewRequest(c.method, c.inURL, c.body, c.options)
+		_, err := testClient.NewRequest(c.method, c.inURL, c.body, c.options)
 
 		if err == nil {
 			t.Errorf("NewRequest(%v, %v, %v, %v) err = %v, expected error", c.method, c.inURL, c.body, c.options, err)


### PR DESCRIPTION
The `http.Client` found in `Client` is now public which it is now possible to use your own `http.Client`.

I also updated the tests as the naming of the `Client` switched between `c` and `client` which was both confusing with the test cases that were also named `c` and the global `Client` that was named `client`. Shadowing of the global test `Client` could make tests fail or pass when they shouldn't.