### PR TITLE
Add support for CustomCollection API

### DIFF
--- a/customcollection.go
+++ b/customcollection.go
@@ -14,7 +14,7 @@ type CustomCollectionService interface {
 	Count(interface{}) (int, error)
 	Get(int, interface{}) (*CustomCollection, error)
 	Create(CustomCollection) (*CustomCollection, error)
-	Update(int, CustomCollection) (*CustomCollection, error)
+	Update(CustomCollection) (*CustomCollection, error)
 	Delete(int) error
 }
 
@@ -82,8 +82,8 @@ func (s *CustomCollectionServiceOp) Create(collection CustomCollection) (*Custom
 }
 
 // Update an existing custom collection
-func (s *CustomCollectionServiceOp) Update(collectionID int, collection CustomCollection) (*CustomCollection, error) {
-	path := fmt.Sprintf("%s/%d.json", customCollectionsBasePath, collectionID)
+func (s *CustomCollectionServiceOp) Update(collection CustomCollection) (*CustomCollection, error) {
+	path := fmt.Sprintf("%s/%d.json", customCollectionsBasePath, collection.ID)
 	wrappedData := CustomCollectionResource{Collection: &collection}
 	resource := new(CustomCollectionResource)
 	err := s.client.Put(path, wrappedData, resource)

--- a/customcollection.go
+++ b/customcollection.go
@@ -2,6 +2,7 @@ package goshopify
 
 import (
 	"fmt"
+	"time"
 )
 
 const customCollectionsBasePath = "admin/custom_collections"
@@ -26,17 +27,17 @@ type CustomCollectionServiceOp struct {
 
 // CustomCollection represents a Shopify custom collection.
 type CustomCollection struct {
-	ID             int    `json:"id"`
-	Handle         string `json:"handle"`
-	Title          string `json:"title"`
-	UpdatedAt      string `json:"updated_at"`
-	BodyHTML       string `json:"body_html"`
-	SortOrder      string `json:"sort_order"`
-	TemplateSuffix string `json:"template_suffix"`
-	Image          Image  `json:"image"`
-	Published      bool   `json:"published"`
-	PublishedAt    string `json:"published_at"`
-	PublishedScope string `json:"published_scope"`
+	ID             int        `json:"id"`
+	Handle         string     `json:"handle"`
+	Title          string     `json:"title"`
+	UpdatedAt      *time.Time `json:"updated_at"`
+	BodyHTML       string     `json:"body_html"`
+	SortOrder      string     `json:"sort_order"`
+	TemplateSuffix string     `json:"template_suffix"`
+	Image          Image      `json:"image"`
+	Published      bool       `json:"published"`
+	PublishedAt    *time.Time `json:"published_at"`
+	PublishedScope string     `json:"published_scope"`
 }
 
 // CustomCollectionResource represents the result form the custom_collections/X.json endpoint

--- a/customcollection.go
+++ b/customcollection.go
@@ -90,7 +90,7 @@ func (s *CustomCollectionServiceOp) Update(collectionID int, collection CustomCo
 	return resource.Collection, err
 }
 
-// Delete an existing image
+// Delete an existing custom collection.
 func (s *CustomCollectionServiceOp) Delete(collectionID int) error {
 	return s.client.Delete(fmt.Sprintf("%s/%d.json", customCollectionsBasePath, collectionID))
 }

--- a/customcollection.go
+++ b/customcollection.go
@@ -1,0 +1,96 @@
+package goshopify
+
+import (
+	"fmt"
+)
+
+const customCollectionsBasePath = "admin/custom_collections"
+
+// CustomCollectionService is an interface for interacting with the custom
+// collection endpoints of the Shopify API.
+// See https://help.shopify.com/api/reference/customcollection
+type CustomCollectionService interface {
+	List(interface{}) ([]CustomCollection, error)
+	Count(interface{}) (int, error)
+	Get(int, interface{}) (*CustomCollection, error)
+	Create(CustomCollection) (*CustomCollection, error)
+	Update(int, CustomCollection) (*CustomCollection, error)
+	Delete(int) error
+}
+
+// CustomCollectionServiceOp handles communication with the custom collection
+// related methods of the Shopify API.
+type CustomCollectionServiceOp struct {
+	client *Client
+}
+
+// CustomCollection represents a Shopify custom collection.
+type CustomCollection struct {
+	ID             int    `json:"id"`
+	Handle         string `json:"handle"`
+	Title          string `json:"title"`
+	UpdatedAt      string `json:"updated_at"`
+	BodyHTML       string `json:"body_html"`
+	SortOrder      string `json:"sort_order"`
+	TemplateSuffix string `json:"template_suffix"`
+	Image          Image  `json:"image"`
+	Published      bool   `json:"published"`
+	PublishedAt    string `json:"published_at"`
+	PublishedScope string `json:"published_scope"`
+}
+
+// CustomCollectionResource represents the result form the custom_collections/X.json endpoint
+type CustomCollectionResource struct {
+	Collection *CustomCollection `json:"custom_collection"`
+}
+
+// CustomCollectionsResource represents the result from the custom_collections.json endpoint
+type CustomCollectionsResource struct {
+	Collections []CustomCollection `json:"custom_collections"`
+}
+
+// List custom collections
+func (s *CustomCollectionServiceOp) List(options interface{}) ([]CustomCollection, error) {
+	path := fmt.Sprintf("%s.json", customCollectionsBasePath)
+	resource := new(CustomCollectionsResource)
+	err := s.client.Get(path, resource, options)
+	return resource.Collections, err
+}
+
+// Count custom collections
+func (s *CustomCollectionServiceOp) Count(options interface{}) (int, error) {
+	path := fmt.Sprintf("%s/count.json", customCollectionsBasePath)
+	return s.client.Count(path, options)
+}
+
+// Get individual custom collection
+func (s *CustomCollectionServiceOp) Get(collectionID int, options interface{}) (*CustomCollection, error) {
+	path := fmt.Sprintf("%s/%d.json", customCollectionsBasePath, collectionID)
+	resource := new(CustomCollectionResource)
+	err := s.client.Get(path, resource, options)
+	return resource.Collection, err
+}
+
+// Create a new custom collection
+// See Image for the details of the Image creation for a collection.
+func (s *CustomCollectionServiceOp) Create(collection CustomCollection) (*CustomCollection, error) {
+	path := fmt.Sprintf("%s.json", customCollectionsBasePath)
+	wrappedData := CustomCollectionResource{Collection: &collection}
+	resource := new(CustomCollectionResource)
+	err := s.client.Post(path, wrappedData, resource)
+	return resource.Collection, err
+}
+
+// Update an existing custom collection
+func (s *CustomCollectionServiceOp) Update(collectionID int, collection CustomCollection) (*CustomCollection, error) {
+	path := fmt.Sprintf("%s/%d.json", customCollectionsBasePath, collectionID)
+	wrappedData := CustomCollectionResource{Collection: &collection}
+	resource := new(CustomCollectionResource)
+	err := s.client.Put(path, wrappedData, resource)
+	return resource.Collection, err
+}
+
+// Delete an existing image
+func (s *CustomCollectionServiceOp) Delete(collectionID int) error {
+	return s.client.Delete(fmt.Sprintf("%s/%d.json", customCollectionsBasePath, collectionID))
+}

--- a/customcollection_test.go
+++ b/customcollection_test.go
@@ -1,0 +1,151 @@
+package goshopify
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	httpmock "gopkg.in/jarcoal/httpmock.v1"
+)
+
+func collectionTests(t *testing.T, collection CustomCollection) {
+
+	// Test a few fields
+	cases := []struct {
+		field    string
+		expected interface{}
+		actual   interface{}
+	}{
+		{"ID", 30497275952, collection.ID},
+		{"Handle", "macbooks", collection.Handle},
+		{"Title", "Macbooks", collection.Title},
+		{"BodyHTML", "Macbook Body", collection.BodyHTML},
+		{"SortOrder", "best-selling", collection.SortOrder},
+	}
+
+	for _, c := range cases {
+		if c.expected != c.actual {
+			t.Errorf("CustomCollection.%v returned %v, expected %v", c.field, c.actual, c.expected)
+		}
+	}
+}
+
+func TestCustomCollectionList(t *testing.T) {
+	setup()
+	defer teardown()
+
+	httpmock.RegisterResponder("GET", "https://fooshop.myshopify.com/admin/custom_collections.json",
+		httpmock.NewStringResponder(200, `{"custom_collections": [{"id":1},{"id":2}]}`))
+
+	products, err := client.CustomCollection.List(nil)
+	if err != nil {
+		t.Errorf("CustomCollection.List returned error: %v", err)
+	}
+
+	expected := []CustomCollection{{ID: 1}, {ID: 2}}
+	if !reflect.DeepEqual(products, expected) {
+		t.Errorf("CustomCollection.List returned %+v, expected %+v", products, expected)
+	}
+}
+
+func TestCustomCollectionCount(t *testing.T) {
+	setup()
+	defer teardown()
+
+	httpmock.RegisterResponder("GET", "https://fooshop.myshopify.com/admin/custom_collections/count.json",
+		httpmock.NewStringResponder(200, `{"count": 5}`))
+
+	httpmock.RegisterResponder("GET", "https://fooshop.myshopify.com/admin/custom_collections/count.json?created_at_min=2016-01-01T00%3A00%3A00Z",
+		httpmock.NewStringResponder(200, `{"count": 2}`))
+
+	cnt, err := client.CustomCollection.Count(nil)
+	if err != nil {
+		t.Errorf("CustomCollection.Count returned error: %v", err)
+	}
+
+	expected := 5
+	if cnt != expected {
+		t.Errorf("CustomCollection.Count returned %d, expected %d", cnt, expected)
+	}
+
+	date := time.Date(2016, time.January, 1, 0, 0, 0, 0, time.UTC)
+	cnt, err = client.CustomCollection.Count(CountOptions{CreatedAtMin: date})
+	if err != nil {
+		t.Errorf("CustomCollection.Count returned error: %v", err)
+	}
+
+	expected = 2
+	if cnt != expected {
+		t.Errorf("CustomCollection.Count returned %d, expected %d", cnt, expected)
+	}
+}
+
+func TestCustomCollectionGet(t *testing.T) {
+	setup()
+	defer teardown()
+
+	httpmock.RegisterResponder("GET", "https://fooshop.myshopify.com/admin/custom_collections/1.json",
+		httpmock.NewStringResponder(200, `{"custom_collection": {"id":1}}`))
+
+	product, err := client.CustomCollection.Get(1, nil)
+	if err != nil {
+		t.Errorf("CustomCollection.Get returned error: %v", err)
+	}
+
+	expected := &CustomCollection{ID: 1}
+	if !reflect.DeepEqual(product, expected) {
+		t.Errorf("CustomCollection.Get returned %+v, expected %+v", product, expected)
+	}
+}
+
+func TestCustomCollectionCreate(t *testing.T) {
+	setup()
+	defer teardown()
+
+	httpmock.RegisterResponder("POST", "https://fooshop.myshopify.com/admin/custom_collections.json",
+		httpmock.NewBytesResponder(200, loadFixture("customcollection.json")))
+
+	collection := CustomCollection{
+		Title: "Macbooks",
+	}
+
+	returnedCollection, err := client.CustomCollection.Create(collection)
+	if err != nil {
+		t.Errorf("CustomCollection.Create returned error: %v", err)
+	}
+
+	collectionTests(t, *returnedCollection)
+}
+
+func TestCustomCollectionUpdate(t *testing.T) {
+	setup()
+	defer teardown()
+
+	httpmock.RegisterResponder("PUT", "https://fooshop.myshopify.com/admin/custom_collections/1.json",
+		httpmock.NewBytesResponder(200, loadFixture("customcollection.json")))
+
+	collection := CustomCollection{
+		ID:    1,
+		Title: "Macbooks",
+	}
+
+	returnedCollection, err := client.CustomCollection.Update(collection.ID, collection)
+	if err != nil {
+		t.Errorf("CustomCollection.Update returned error: %v", err)
+	}
+
+	collectionTests(t, *returnedCollection)
+}
+
+func TestCustomCollectionDelete(t *testing.T) {
+	setup()
+	defer teardown()
+
+	httpmock.RegisterResponder("DELETE", "https://fooshop.myshopify.com/admin/custom_collections/1.json",
+		httpmock.NewStringResponder(200, "{}"))
+
+	err := client.CustomCollection.Delete(1)
+	if err != nil {
+		t.Errorf("CustomCollection.Delete returned error: %v", err)
+	}
+}

--- a/customcollection_test.go
+++ b/customcollection_test.go
@@ -129,7 +129,7 @@ func TestCustomCollectionUpdate(t *testing.T) {
 		Title: "Macbooks",
 	}
 
-	returnedCollection, err := client.CustomCollection.Update(collection.ID, collection)
+	returnedCollection, err := client.CustomCollection.Update(collection)
 	if err != nil {
 		t.Errorf("CustomCollection.Update returned error: %v", err)
 	}

--- a/fixtures/customcollection.json
+++ b/fixtures/customcollection.json
@@ -1,0 +1,1 @@
+{"custom_collection":{"id":30497275952,"handle":"macbooks","title":"Macbooks","updated_at":"2018-02-06T02:20:25-05:00","body_html":"Macbook Body","published_at":"2018-02-06T02:20:25-05:00","sort_order":"best-selling","template_suffix":null,"published_scope":"web"}}

--- a/goshopify.go
+++ b/goshopify.go
@@ -47,14 +47,15 @@ type Client struct {
 	token string
 
 	// Services used for communicating with the API
-	Product     ProductService
-	Customer    CustomerService
-	Order       OrderService
-	Shop        ShopService
-	Webhook     WebhookService
-	Variant     VariantService
-	Image       ImageService
-	Transaction TransactionService
+	Product          ProductService
+	CustomCollection CustomCollectionService
+	Customer         CustomerService
+	Order            OrderService
+	Shop             ShopService
+	Webhook          WebhookService
+	Variant          VariantService
+	Image            ImageService
+	Transaction      TransactionService
 }
 
 // A general response error that follows a similar layout to Shopify's response
@@ -150,6 +151,7 @@ func NewClient(app App, shopName, token string) *Client {
 
 	c := &Client{Client: httpClient, app: app, baseURL: baseURL, token: token}
 	c.Product = &ProductServiceOp{client: c}
+	c.CustomCollection = &CustomCollectionServiceOp{client: c}
 	c.Customer = &CustomerServiceOp{client: c}
 	c.Order = &OrderServiceOp{client: c}
 	c.Shop = &ShopServiceOp{client: c}


### PR DESCRIPTION
PR adds support for the CustomCollection APIs from shopify.

[https://help.shopify.com/api/reference/customcollection](https://help.shopify.com/api/reference/customcollection)