### PR TITLE
Fix oauth when state (or other params) contain values that would be url encoded.

### DIFF
--- a/oauth.go
+++ b/oauth.go
@@ -65,7 +65,7 @@ func (app App) VerifyMessage(message, messageMAC string) bool {
 }
 
 // Verifying URL callback parameters.
-func (app App) VerifyAuthorizationURL(u *url.URL) bool {
+func (app App) VerifyAuthorizationURL(u *url.URL) (bool, error) {
 	q := u.Query()
 	messageMAC := q.Get("hmac")
 
@@ -73,9 +73,9 @@ func (app App) VerifyAuthorizationURL(u *url.URL) bool {
 	q.Del("hmac")
 	q.Del("signature")
 
-	message := q.Encode()
+	message, err := url.QueryUnescape(q.Encode())
 
-	return app.VerifyMessage(message, messageMAC)
+	return app.VerifyMessage(message, messageMAC), err
 }
 
 // Verifies a webhook http request, sent by Shopify.

--- a/oauth_test.go
+++ b/oauth_test.go
@@ -63,13 +63,15 @@ func TestAppVerifyAuthorizationURL(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		actual := app.VerifyAuthorizationURL(c.u)
+		actual, err := app.VerifyAuthorizationURL(c.u)
+		if err != nil {
+			t.Errorf("App.VerifyAuthorizationURL(..., %s) returned an error:", c.u, err)
+		}
 		if actual != c.expected {
 			t.Errorf("App.VerifyAuthorizationURL(..., %s): expected %v, actual %v", c.u, c.expected, actual)
 		}
 	}
 }
-
 
 func TestVerifyWebhookRequest(t *testing.T) {
 	setup()


### PR DESCRIPTION
The way q.Encode() works causes the message to be fully url escaped, this leads to problems verifying the hmac that Shopify will send with the oauth request due to them comparing against non-escaped characters.