### PR TITLE
Update note attributes value type

### DIFF
--- a/order.go
+++ b/order.go
@@ -154,8 +154,8 @@ type LineItemProperty struct {
 }
 
 type NoteAttribute struct {
-	Name  string `json:"Name"`
-	Value string `json:"Value"`
+	Name  string      `json:"Name"`
+	Value interface{} `json:"Value"`
 }
 
 // Represents the result from the orders/X.json endpoint


### PR DESCRIPTION
Although the note_attributes value should be string according to this doc:
https://help.shopify.com/api/reference/order#properties

We might get it as int. For that reason we use interface type: `interface{}`

Order note attributes for example:
```json
"note_attributes": [
      {
        "name": "Sales Channel",
        "value": "Media"
      },
      {
        "name": "Sales Channel ID",
        "value": 23
      }
]
```