### PR TITLE
Handle 406 errors

### DIFF
--- a/customer_test.go
+++ b/customer_test.go
@@ -122,7 +122,7 @@ func TestCustomerGet(t *testing.T) {
 	if customer.State != expectation.State {
 		t.Errorf("Customer.State returned %+v, expected %+v", customer.State, expectation.State)
 	}
-	if !expectation.TotalSpent.Equals(*customer.TotalSpent) {
+	if !expectation.TotalSpent.Truncate(2).Equals(customer.TotalSpent.Truncate(2)) {
 		t.Errorf("Customer.TotalSpent returned %+v, expected %+v", customer.TotalSpent, expectation.TotalSpent)
 	}
 	if customer.LastOrderId != expectation.LastOrderId {

--- a/goshopify_test.go
+++ b/goshopify_test.go
@@ -250,6 +250,14 @@ func TestDo(t *testing.T) {
 				},
 			},
 		},
+		{
+			"foo/7",
+			httpmock.NewStringResponder(406, ``),
+			ResponseError{
+				Status:  406,
+				Message: "Not acceptable",
+			},
+		},
 	}
 
 	for _, c := range cases {

--- a/oauth_test.go
+++ b/oauth_test.go
@@ -65,7 +65,7 @@ func TestAppVerifyAuthorizationURL(t *testing.T) {
 	for _, c := range cases {
 		actual, err := app.VerifyAuthorizationURL(c.u)
 		if err != nil {
-			t.Errorf("App.VerifyAuthorizationURL(..., %s) returned an error:", c.u, err)
+			t.Errorf("App.VerifyAuthorizationURL(..., %s) returned an error: %v", c.u, err)
 		}
 		if actual != c.expected {
 			t.Errorf("App.VerifyAuthorizationURL(..., %s): expected %v, actual %v", c.u, c.expected, actual)
@@ -89,6 +89,6 @@ func TestVerifyWebhookRequest(t *testing.T) {
 	isValid := app.VerifyWebhookRequest(req)
 
 	if !isValid {
-		t.Errorf("Webhook.verify could not verified message checksum")
+		t.Error("Webhook.verify could not verified message checksum")
 	}
 }


### PR DESCRIPTION
Shopify doesn't return a json body for 406 errors (for example, if you send an array of assets instead of
a single asset to the theme/{themeid}/assets.json endpoint), so this resulted in a json decoder EOF error
rather than a Shopify 406 error. Shopify returns "406 Not Acceptable" though, so return that in the error
string instead.

It might not be perfect, but it's at least less confusing to troubleshoot