### PR TITLE
Order count options missing fields

### DIFF
--- a/order.go
+++ b/order.go
@@ -95,6 +95,16 @@ type Order struct {
 	Refunds               []Refund         `json:"refunds"`
 	UserId                int              `json:"user_id"`
 	OrderStatusUrl        string           `json:"order_status_url"`
+	Gateway               string           `json:"gateway"`
+	Confirmed             bool             `json:"confirmed"`
+	TotalPriceUSD         *decimal.Decimal `json:"total_price_usd"`
+	CheckoutToken         string           `json:"checkout_token"`
+	Reference             string           `json:"reference"`
+	SourceIdentifier      string           `json:"source_identifier"`
+	SourceURL             string           `json:"source_url"`
+	DeviceID              int              `json:"device_id"`
+	Phone                 string           `json:"phone"`
+	LandingSiteRef        string           `json:"landing_site_ref"`
 }
 
 type Address struct {

--- a/order.go
+++ b/order.go
@@ -24,6 +24,22 @@ type OrderServiceOp struct {
 	client *Client
 }
 
+// A struct for all available order count options
+type OrderCountOptions struct {
+	Page              int       `url:"page,omitempty"`
+	Limit             int       `url:"limit,omitempty"`
+	SinceID           int       `url:"since_id,omitempty"`
+	CreatedAtMin      time.Time `url:"created_at_min,omitempty"`
+	CreatedAtMax      time.Time `url:"created_at_max,omitempty"`
+	UpdatedAtMin      time.Time `url:"updated_at_min,omitempty"`
+	UpdatedAtMax      time.Time `url:"updated_at_max,omitempty"`
+	Order             string    `url:"order,omitempty"`
+	Fields            string    `url:"fields,omitempty"`
+	Status            string    `url:"status,omitempty"`
+	FinancialStatus   string    `url:"financial_status,omitempty"`
+	FulfillmentStatus string    `url:"fulfillment_status,omitempty"`
+}
+
 // A struct for all available order list options.
 // See: https://help.shopify.com/api/reference/order#index
 type OrderListOptions struct {

--- a/order.go
+++ b/order.go
@@ -105,6 +105,8 @@ type Order struct {
 	DeviceID              int              `json:"device_id"`
 	Phone                 string           `json:"phone"`
 	LandingSiteRef        string           `json:"landing_site_ref"`
+	CheckoutID            int              `json:"checkout_id"`
+	ContactEmail          string           `json:"contact_email"`
 }
 
 type Address struct {

--- a/order_test.go
+++ b/order_test.go
@@ -178,7 +178,7 @@ func TestOrderCount(t *testing.T) {
 	}
 
 	date := time.Date(2016, time.January, 1, 0, 0, 0, 0, time.UTC)
-	cnt, err = client.Order.Count(CountOptions{CreatedAtMin: date})
+	cnt, err = client.Order.Count(OrderCountOptions{CreatedAtMin: date})
 	if err != nil {
 		t.Errorf("Order.Count returned error: %v", err)
 	}


### PR DESCRIPTION
Order count exposes a few extra fields that the normal count doesn't provide.

This allows you to get accurate counts for search terms you might use when fetching orders.