### PR TITLE
Add IDs []int as option for List method in client.

### DIFF
--- a/goshopify.go
+++ b/goshopify.go
@@ -322,6 +322,7 @@ type ListOptions struct {
 	UpdatedAtMax time.Time `url:"updated_at_max,omitempty"`
 	Order        string    `url:"order,omitempty"`
 	Fields       string    `url:"fields,omitempty"`
+	IDs          []int     `url:"ids,omitempty"`
 }
 
 // General count options that can be used for most collection counts.


### PR DESCRIPTION
This is a simple PR allows the user to pick an object from the Shopify API based
on one or more individual IDs.