### PR TITLE
Add RecurringApplicationCharge support

### DIFF
--- a/fixtures/reccuringapplicationcharge.json
+++ b/fixtures/reccuringapplicationcharge.json
@@ -1,0 +1,20 @@
+{
+  "recurring_application_charge": {
+    "id": 1029266948,
+    "name": "Super Duper Plan",
+    "api_client_id": 755357713,
+    "price": "10.00",
+    "status": "pending",
+    "return_url": "http://super-duper.shopifyapps.com/",
+    "billing_on": null,
+    "created_at": "2018-05-07T15:47:10-04:00",
+    "updated_at": "2018-05-07T15:47:10-04:00",
+    "test": null,
+    "activated_on": null,
+    "trial_ends_on": null,
+    "cancelled_on": null,
+    "trial_days": 0,
+    "decorated_return_url": "http://super-duper.shopifyapps.com/?charge_id=1029266948",
+    "confirmation_url": "https://apple.myshopify.com/admin/charges/1029266948/confirm_recurring_application_charge?signature=BAhpBAReWT0%3D--b51a6db06a3792c4439783fcf0f2e89bf1c9df68"
+  }
+}

--- a/goshopify.go
+++ b/goshopify.go
@@ -48,19 +48,20 @@ type Client struct {
 	token string
 
 	// Services used for communicating with the API
-	Product          ProductService
-	CustomCollection CustomCollectionService
-	SmartCollection  SmartCollectionService
-	Customer         CustomerService
-	Order            OrderService
-	Shop             ShopService
-	Webhook          WebhookService
-	Variant          VariantService
-	Image            ImageService
-	Transaction      TransactionService
-	Theme            ThemeService
-	Asset            AssetService
-	ScriptTag        ScriptTagService
+	Product                    ProductService
+	CustomCollection           CustomCollectionService
+	SmartCollection            SmartCollectionService
+	Customer                   CustomerService
+	Order                      OrderService
+	Shop                       ShopService
+	Webhook                    WebhookService
+	Variant                    VariantService
+	Image                      ImageService
+	Transaction                TransactionService
+	Theme                      ThemeService
+	Asset                      AssetService
+	ScriptTag                  ScriptTagService
+	RecurringApplicationCharge RecurringApplicationChargeService
 }
 
 // A general response error that follows a similar layout to Shopify's response
@@ -180,6 +181,7 @@ func NewClient(app App, shopName, token string) *Client {
 	c.Theme = &ThemeServiceOp{client: c}
 	c.Asset = &AssetServiceOp{client: c}
 	c.ScriptTag = &ScriptTagServiceOp{client: c}
+	c.RecurringApplicationCharge = &RecurringApplicationChargeServiceOp{client: c}
 
 	return c
 }

--- a/recurringapplicationcharge.go
+++ b/recurringapplicationcharge.go
@@ -30,7 +30,7 @@ type RecurringApplicationChargeServiceOp struct {
 // RecurringApplicationCharge represents a Shopify RecurringApplicationCharge.
 type RecurringApplicationCharge struct {
 	APIClientID           int              `json:"api_client_id"`
-	ActivatedOn           *time.Time       `json:"activated_on "`
+	ActivatedOn           *time.Time       `json:"activated_on"`
 	BalanceRemaining      *decimal.Decimal `json:"balance_remaining"`
 	BalanceUsed           *decimal.Decimal `json:"balance_used"`
 	BillingOn             *time.Time       `json:"billing_on"`

--- a/recurringapplicationcharge.go
+++ b/recurringapplicationcharge.go
@@ -1,0 +1,124 @@
+package goshopify
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+const recurringApplicationChargesBasePath = "admin/recurring_application_charges"
+
+// RecurringApplicationChargeService is an interface for interacting with the
+// RecurringApplicationCharge endpoints of the Shopify API.
+// See https://help.shopify.com/api/reference/billing/recurringapplicationcharge
+type RecurringApplicationChargeService interface {
+	Create(RecurringApplicationCharge) (*RecurringApplicationCharge, error)
+	Get(int, interface{}) (*RecurringApplicationCharge, error)
+	List(interface{}) ([]RecurringApplicationCharge, error)
+	Activate(RecurringApplicationCharge) (*RecurringApplicationCharge, error)
+	Delete(int) error
+	Update(int, int) (*RecurringApplicationCharge, error)
+}
+
+// RecurringApplicationChargeServiceOp handles communication with the
+// RecurringApplicationCharge related methods of the Shopify API.
+type RecurringApplicationChargeServiceOp struct {
+	client *Client
+}
+
+// RecurringApplicationCharge represents a Shopify RecurringApplicationCharge.
+type RecurringApplicationCharge struct {
+	APIClientID           int              `json:"api_client_id"`
+	ActivatedOn           *time.Time       `json:"activated_on "`
+	BalanceRemaining      *decimal.Decimal `json:"balance_remaining"`
+	BalanceUsed           *decimal.Decimal `json:"balance_used"`
+	BillingOn             *time.Time       `json:"billing_on"`
+	CancelledOn           *time.Time       `json:"cancelled_on"`
+	CappedAmount          *decimal.Decimal `json:"capped_amount"`
+	ConfirmationURL       string           `json:"confirmation_url"`
+	CreatedAt             *time.Time       `json:"created_at"`
+	DecoratedReturnURL    string           `json:"decorated_return_url"`
+	ID                    int              `json:"id"`
+	Name                  string           `json:"name"`
+	Price                 *decimal.Decimal `json:"price"`
+	ReturnURL             string           `json:"return_url"`
+	RiskLevel             *decimal.Decimal `json:"risk_level"`
+	Status                string           `json:"status"`
+	Terms                 string           `json:"terms"`
+	Test                  *bool            `json:"test"`
+	TrialDays             int              `json:"trial_days"`
+	TrialEndsOn           *time.Time       `json:"trial_ends_on"`
+	UpdateCappedAmountURL string           `json:"update_capped_amount_url"`
+	UpdatedAt             *time.Time       `json:"updated_at"`
+}
+
+// RecurringApplicationChargeResource represents the result from the
+// admin/recurring_application_charges{/X{/activate.json}.json}.json endpoints.
+type RecurringApplicationChargeResource struct {
+	Charge *RecurringApplicationCharge `json:"recurring_application_charge"`
+}
+
+// RecurringApplicationChargesResource represents the result from the
+// admin/recurring_application_charges.json endpoint.
+type RecurringApplicationChargesResource struct {
+	Charges []RecurringApplicationCharge `json:"recurring_application_charges"`
+}
+
+// Create creates new recurring application charge.
+func (r *RecurringApplicationChargeServiceOp) Create(charge RecurringApplicationCharge) (
+	*RecurringApplicationCharge, error) {
+
+	path := fmt.Sprintf("%s.json", recurringApplicationChargesBasePath)
+	wrappedData := RecurringApplicationChargeResource{Charge: &charge}
+	resource := &RecurringApplicationChargeResource{}
+	err := r.client.Post(path, wrappedData, resource)
+	return resource.Charge, err
+}
+
+// Get gets individual recurring application charge.
+func (r *RecurringApplicationChargeServiceOp) Get(chargeID int, options interface{}) (
+	*RecurringApplicationCharge, error) {
+
+	path := fmt.Sprintf("%s/%d.json", recurringApplicationChargesBasePath, chargeID)
+	resource := &RecurringApplicationChargeResource{}
+	err := r.client.Get(path, resource, options)
+	return resource.Charge, err
+}
+
+// List gets all recurring application charges.
+func (r *RecurringApplicationChargeServiceOp) List(options interface{}) (
+	[]RecurringApplicationCharge, error) {
+
+	path := fmt.Sprintf("%s.json", recurringApplicationChargesBasePath)
+	resource := &RecurringApplicationChargesResource{}
+	err := r.client.Get(path, resource, options)
+	return resource.Charges, err
+}
+
+// Activate activates recurring application charge.
+func (r *RecurringApplicationChargeServiceOp) Activate(charge RecurringApplicationCharge) (
+	*RecurringApplicationCharge, error) {
+
+	path := fmt.Sprintf("%s/%d/activate.json", recurringApplicationChargesBasePath, charge.ID)
+	wrappedData := RecurringApplicationChargeResource{Charge: &charge}
+	resource := &RecurringApplicationChargeResource{}
+	err := r.client.Post(path, wrappedData, resource)
+	return resource.Charge, err
+}
+
+// Delete deletes recurring application charge.
+func (r *RecurringApplicationChargeServiceOp) Delete(chargeID int) error {
+	return r.client.Delete(fmt.Sprintf("%s/%d.json", recurringApplicationChargesBasePath, chargeID))
+}
+
+// Update updates recurring application charge.
+func (r *RecurringApplicationChargeServiceOp) Update(chargeID, newCappedAmount int) (
+	*RecurringApplicationCharge, error) {
+
+	path := fmt.Sprintf("%s/%d/customize.json?recurring_application_charge[capped_amount]=%d",
+		recurringApplicationChargesBasePath, chargeID, newCappedAmount)
+	resource := &RecurringApplicationChargeResource{}
+	err := r.client.Put(path, nil, resource)
+	return resource.Charge, err
+}

--- a/recurringapplicationcharge_test.go
+++ b/recurringapplicationcharge_test.go
@@ -1,0 +1,194 @@
+package goshopify
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"gopkg.in/jarcoal/httpmock.v1"
+)
+
+// recurringApplicationChargeTests tests if the fields are properly parsed.
+func recurringApplicationChargeTests(t *testing.T, charge RecurringApplicationCharge) {
+	var (
+		nilTime *time.Time
+		nilTest *bool
+	)
+
+	cases := []struct {
+		field    string
+		expected interface{}
+		actual   interface{}
+	}{
+		{"ID", 1029266948, charge.ID},
+		{"Name", "Super Duper Plan", charge.Name},
+		{"APIClientID", 755357713, charge.APIClientID},
+		{"Price", decimal.NewFromFloat(10.00).String(), charge.Price.String()},
+		{"Status", "pending", charge.Status},
+		{"ReturnURL", "http://super-duper.shopifyapps.com/", charge.ReturnURL},
+		{"BillingOn", nilTime, charge.BillingOn},
+		{"CreatedAt", "2018-05-07T15:47:10-04:00", charge.CreatedAt.Format(time.RFC3339)},
+		{"UpdatedAt", "2018-05-07T15:47:10-04:00", charge.UpdatedAt.Format(time.RFC3339)},
+		{"Test", nilTest, charge.Test},
+		{"ActivatedOn", nilTime, charge.ActivatedOn},
+		{"TrialEndsOn", nilTime, charge.TrialEndsOn},
+		{"CancelledOn", nilTime, charge.CancelledOn},
+		{"TrialDays", 0, charge.TrialDays},
+		{
+			"DecoratedReturnURL",
+			"http://super-duper.shopifyapps.com/?charge_id=1029266948",
+			charge.DecoratedReturnURL,
+		},
+		{
+			"ConfirmationURL",
+			"https://apple.myshopify.com/admin/charges/1029266948/confirm_recurring_application_c" +
+				"harge?signature=BAhpBAReWT0%3D--b51a6db06a3792c4439783fcf0f2e89bf1c9df68",
+			charge.ConfirmationURL,
+		},
+	}
+
+	for _, c := range cases {
+		if c.expected != c.actual {
+			t.Errorf("RecurringApplicationCharge.%s returned %v, expected %v", c.field, c.actual,
+				c.expected)
+		}
+	}
+}
+
+func TestRecurringApplicationChargeServiceOp_Create(t *testing.T) {
+	setup()
+	defer teardown()
+
+	httpmock.RegisterResponder(
+		"POST",
+		"https://fooshop.myshopify.com/admin/recurring_application_charges.json",
+		httpmock.NewBytesResponder(200, loadFixture("reccuringapplicationcharge.json")),
+	)
+
+	p := decimal.NewFromFloat(10.0)
+	charge := RecurringApplicationCharge{
+		Name:      "Super Duper Plan",
+		Price:     &p,
+		ReturnURL: "http://super-duper.shopifyapps.com",
+	}
+
+	returnedCharge, err := client.RecurringApplicationCharge.Create(charge)
+	if err != nil {
+		t.Errorf("RecurringApplicationCharge.Create returned an error: %v", err)
+	}
+
+	recurringApplicationChargeTests(t, *returnedCharge)
+}
+
+func TestRecurringApplicationChargeServiceOp_Get(t *testing.T) {
+	setup()
+	defer teardown()
+
+	httpmock.RegisterResponder(
+		"GET",
+		"https://fooshop.myshopify.com/admin/recurring_application_charges/1.json",
+		httpmock.NewStringResponder(200, `{"recurring_application_charge": {"id":1}}`),
+	)
+
+	charge, err := client.RecurringApplicationCharge.Get(1, nil)
+	if err != nil {
+		t.Errorf("RecurringApplicationCharge.Get returned an error: %v", err)
+	}
+
+	expected := &RecurringApplicationCharge{ID: 1}
+	if !reflect.DeepEqual(charge, expected) {
+		t.Errorf("RecurringApplicationCharge.Get returned %+v, expected %+v", charge, expected)
+	}
+}
+
+func TestRecurringApplicationChargeServiceOp_List(t *testing.T) {
+	setup()
+	defer teardown()
+
+	httpmock.RegisterResponder(
+		"GET",
+		"https://fooshop.myshopify.com/admin/recurring_application_charges.json",
+		httpmock.NewStringResponder(200, `{"recurring_application_charges": [{"id":1},{"id":2}]}`),
+	)
+
+	charges, err := client.RecurringApplicationCharge.List(nil)
+	if err != nil {
+		t.Errorf("RecurringApplicationCharge.List returned an error: %v", err)
+	}
+
+	expected := []RecurringApplicationCharge{{ID: 1}, {ID: 2}}
+	if !reflect.DeepEqual(charges, expected) {
+		t.Errorf("RecurringApplicationCharge.List returned %+v, expected %+v", charges, expected)
+	}
+}
+
+func TestRecurringApplicationChargeServiceOp_Activate(t *testing.T) {
+	setup()
+	defer teardown()
+
+	httpmock.RegisterResponder(
+		"POST",
+		"https://fooshop.myshopify.com/admin/recurring_application_charges/455696195/activate.json",
+		httpmock.NewStringResponder(
+			200,
+			`{"recurring_application_charge":{"id":455696195,"status":"active"}}`,
+		),
+	)
+
+	charge := RecurringApplicationCharge{
+		ID:     455696195,
+		Status: "accepted",
+	}
+
+	returnedCharge, err := client.RecurringApplicationCharge.Activate(charge)
+	if err != nil {
+		t.Errorf("RecurringApplicationCharge.Activate returned an error: %v", err)
+	}
+
+	expected := &RecurringApplicationCharge{ID: 455696195, Status: "active"}
+	if !reflect.DeepEqual(returnedCharge, expected) {
+		t.Errorf("RecurringApplicationCharge.Activate returned %+v, expected %+v", charge, expected)
+	}
+}
+
+func TestRecurringApplicationChargeServiceOp_Delete(t *testing.T) {
+	setup()
+	defer teardown()
+
+	httpmock.RegisterResponder(
+		"DELETE",
+		"https://fooshop.myshopify.com/admin/recurring_application_charges/1.json",
+		httpmock.NewStringResponder(200, "{}"),
+	)
+
+	if err := client.RecurringApplicationCharge.Delete(1); err != nil {
+		t.Errorf("RecurringApplicationCharge.Delete returned an error: %v", err)
+	}
+}
+
+func TestRecurringApplicationChargeServiceOp_Update(t *testing.T) {
+	setup()
+	defer teardown()
+
+	httpmock.RegisterResponder(
+		"PUT",
+		"https://fooshop.myshopify.com/admin/recurring_application_charges/455696195/customize.jso"+
+			"n?recurring_application_charge[capped_amount]=100",
+		httpmock.NewStringResponder(
+			200,
+			`{"recurring_application_charge":{"id":455696195,"capped_amount":"100.00"}}`,
+		),
+	)
+
+	charge, err := client.RecurringApplicationCharge.Update(455696195, 100)
+	if err != nil {
+		t.Errorf("RecurringApplicationCharge.Update returned an error: %v", err)
+	}
+
+	ca := decimal.NewFromFloat(100.00)
+	expected := &RecurringApplicationCharge{ID: 455696195, CappedAmount: &ca}
+	if !reflect.DeepEqual(charge, expected) {
+		t.Errorf("RecurringApplicationCharge.Update returned %+v, expected %+v", charge, expected)
+	}
+}

--- a/scripttag.go
+++ b/scripttag.go
@@ -48,13 +48,14 @@ type ScriptTagOption struct {
 	Fields       string    `url:"fields,omitempty"`
 }
 
-// Represents the result from the /admin/script_tags.json endpoint.
+// ScriptTagsResource represents the result from the admin/script_tags.json
+// endpoint.
 type ScriptTagsResource struct {
 	ScriptTags []ScriptTag `json:"script_tags"`
 }
 
-// Represents the result from the /admin/script_tags/{#script_tag_id}.json
-// endpoint.
+// ScriptTagResource represents the result from the
+// admin/script_tags/{#script_tag_id}.json endpoint.
 type ScriptTagResource struct {
 	ScriptTag *ScriptTag `json:"script_tag"`
 }

--- a/smartcollection.go
+++ b/smartcollection.go
@@ -48,7 +48,7 @@ type SmartCollection struct {
 	Disjunctive    bool       `json:"disjunctive"`
 }
 
-// SmartCollectionResource represents the result form the smart_collections/X.json endpoint
+// SmartCollectionResource represents the result from the smart_collections/X.json endpoint
 type SmartCollectionResource struct {
 	Collection *SmartCollection `json:"smart_collection"`
 }

--- a/smartcollection_test.go
+++ b/smartcollection_test.go
@@ -3,13 +3,12 @@ package goshopify
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	httpmock "gopkg.in/jarcoal/httpmock.v1"
-	"time"
 )
 
 func smartCollectionTests(t *testing.T, collection SmartCollection) {
-
 	// Test a few fields
 	cases := []struct {
 		field    string


### PR DESCRIPTION
I have added RecurringApplicationCharge (https://help.shopify.com/api/reference/billing/recurringapplicationcharge) support to the API. I tried to achieve consistency with the rest of the lib and, of course, if you spot otherwise - I'll be happy to clear that out.

There was unfortunately a problem. If you take a look at the provided docs, you can see that the RecurringApplicationCharge Properties are not actually all the fields that Shopify could return in a response. This is particularly observed when creating a recurring app charge with a capped amount + terms. Therefore I had looked at all the provided responses and gathered all the possible (I think?) fields. This code is going to get battle-tested at my company, so if anything unforeseen occurs, I'm going to fix that immediately and make a PR.