### PR TITLE
A workaround an API returning only dates, but missing time and timezone.

### DIFF
--- a/fixtures/reccuringapplicationcharge.json
+++ b/fixtures/reccuringapplicationcharge.json
@@ -10,7 +10,7 @@
     "created_at": "2018-05-07T15:47:10-04:00",
     "updated_at": "2018-05-07T15:47:10-04:00",
     "test": null,
-    "activated_on": null,
+    "activated_on": "2018-06-05",
     "trial_ends_on": null,
     "cancelled_on": null,
     "trial_days": 0,

--- a/recurringapplicationcharge_test.go
+++ b/recurringapplicationcharge_test.go
@@ -31,7 +31,7 @@ func recurringApplicationChargeTests(t *testing.T, charge RecurringApplicationCh
 		{"CreatedAt", "2018-05-07T15:47:10-04:00", charge.CreatedAt.Format(time.RFC3339)},
 		{"UpdatedAt", "2018-05-07T15:47:10-04:00", charge.UpdatedAt.Format(time.RFC3339)},
 		{"Test", nilTest, charge.Test},
-		{"ActivatedOn", nilTime, charge.ActivatedOn},
+		{"ActivatedOn", "2018-06-05", charge.ActivatedOn.Format("2006-01-02")},
 		{"TrialEndsOn", nilTime, charge.TrialEndsOn},
 		{"CancelledOn", nilTime, charge.CancelledOn},
 		{"TrialDays", 0, charge.TrialDays},


### PR DESCRIPTION
In some cases Shopify returns a shortened timestamp:
https://ecommerce.shopify.com/c/shopify-apis-and-technology/t/-523203

This is a workaround.