### PR TITLE
Omitempty customer product metafield variant fields

### DIFF
--- a/customer.go
+++ b/customer.go
@@ -33,27 +33,27 @@ type CustomerServiceOp struct {
 
 // Customer represents a Shopify customer
 type Customer struct {
-	ID                  int                `json:"id"`
-	Email               string             `json:"email"`
-	FirstName           string             `json:"first_name"`
-	LastName            string             `json:"last_name"`
-	State               string             `json:"state"`
-	Note                string             `json:"note"`
-	VerifiedEmail       bool               `json:"verified_email"`
-	MultipassIdentifier string             `json:"multipass_identifier"`
-	OrdersCount         int                `json:"orders_count"`
-	TaxExempt           bool               `json:"tax_exempt"`
-	TotalSpent          *decimal.Decimal   `json:"total_spent"`
-	Phone               string             `json:"phone"`
-	Tags                string             `json:"tags"`
-	LastOrderId         int                `json:"last_order_id"`
-	LastOrderName       string             `json:"last_order_name"`
-	AcceptsMarketing    bool               `json:"accepts_marketing"`
-	DefaultAddress      *CustomerAddress   `json:"default_address"`
-	Addresses           []*CustomerAddress `json:"addresses"`
-	CreatedAt           *time.Time         `json:"created_at"`
-	UpdatedAt           *time.Time         `json:"updated_at"`
-	Metafields          []Metafield        `json:"metafields"`
+	ID                  int                `json:"id,omitempty"`
+	Email               string             `json:"email,omitempty"`
+	FirstName           string             `json:"first_name,omitempty"`
+	LastName            string             `json:"last_name,omitempty"`
+	State               string             `json:"state,omitempty"`
+	Note                string             `json:"note,omitempty"`
+	VerifiedEmail       bool               `json:"verified_email,omitempty"`
+	MultipassIdentifier string             `json:"multipass_identifier,omitempty"`
+	OrdersCount         int                `json:"orders_count,omitempty"`
+	TaxExempt           bool               `json:"tax_exempt,omitempty"`
+	TotalSpent          *decimal.Decimal   `json:"total_spent,omitempty"`
+	Phone               string             `json:"phone,omitempty"`
+	Tags                string             `json:"tags,omitempty"`
+	LastOrderId         int                `json:"last_order_id,omitempty"`
+	LastOrderName       string             `json:"last_order_name,omitempty"`
+	AcceptsMarketing    bool               `json:"accepts_marketing,omitempty"`
+	DefaultAddress      *CustomerAddress   `json:"default_address,omitempty"`
+	Addresses           []*CustomerAddress `json:"addresses,omitempty"`
+	CreatedAt           *time.Time         `json:"created_at,omitempty"`
+	UpdatedAt           *time.Time         `json:"updated_at,omitempty"`
+	Metafields          []Metafield        `json:"metafields,omitempty"`
 }
 
 // Represents the result from the customers/X.json endpoint

--- a/metafield.go
+++ b/metafield.go
@@ -39,16 +39,16 @@ type MetafieldServiceOp struct {
 
 // Metafield represents a Shopify metafield.
 type Metafield struct {
-	ID            int         `json:"id"`
-	Key           string      `json:"key"`
-	Value         interface{} `json:"value"`
-	ValueType     string      `json:"value_type"`
-	Namespace     string      `json:"namespace"`
-	Description   string      `json:"description"`
-	OwnerId       int         `json:"owner_id"`
-	CreatedAt     *time.Time  `json:"created_at"`
-	UpdatedAt     *time.Time  `json:"updated_at"`
-	OwnerResource string      `json:"owner_resource"`
+	ID            int         `json:"id,omitempty"`
+	Key           string      `json:"key,omitempty"`
+	Value         interface{} `json:"value,omitempty"`
+	ValueType     string      `json:"value_type,omitempty"`
+	Namespace     string      `json:"namespace,omitempty"`
+	Description   string      `json:"description,omitempty"`
+	OwnerId       int         `json:"owner_id,omitempty"`
+	CreatedAt     *time.Time  `json:"created_at,omitempty"`
+	UpdatedAt     *time.Time  `json:"updated_at,omitempty"`
+	OwnerResource string      `json:"owner_resource,omitempty"`
 }
 
 // MetafieldResource represents the result from the metafields/X.json endpoint

--- a/product.go
+++ b/product.go
@@ -31,34 +31,34 @@ type ProductServiceOp struct {
 
 // Product represents a Shopify product
 type Product struct {
-	ID                             int             `json:"id"`
-	Title                          string          `json:"title"`
-	BodyHTML                       string          `json:"body_html"`
-	Vendor                         string          `json:"vendor"`
-	ProductType                    string          `json:"product_type"`
-	Handle                         string          `json:"handle"`
-	CreatedAt                      *time.Time      `json:"created_at"`
-	UpdatedAt                      *time.Time      `json:"updated_at"`
-	PublishedAt                    *time.Time      `json:"published_at"`
-	PublishedScope                 string          `json:"published_scope"`
-	Tags                           string          `json:"tags"`
-	Options                        []ProductOption `json:"options"`
-	Variants                       []Variant       `json:"variants"`
-	Image                          Image           `json:"image"`
-	Images                         []Image         `json:"images"`
-	TemplateSuffix                 string          `json:"template_suffix"`
-	MetafieldsGlobalTitleTag       string          `json:"metafields_global_title_tag"`
-	MetafieldsGlobalDescriptionTag string          `json:"metafields_global_description_tag"`
-	Metafields                     []Metafield     `json:"metafields"`
+	ID                             int             `json:"id,omitempty"`
+	Title                          string          `json:"title,omitempty"`
+	BodyHTML                       string          `json:"body_html,omitempty"`
+	Vendor                         string          `json:"vendor,omitempty"`
+	ProductType                    string          `json:"product_type,omitempty"`
+	Handle                         string          `json:"handle,omitempty"`
+	CreatedAt                      *time.Time      `json:"created_at,omitempty"`
+	UpdatedAt                      *time.Time      `json:"updated_at,omitempty"`
+	PublishedAt                    *time.Time      `json:"published_at,omitempty"`
+	PublishedScope                 string          `json:"published_scope,omitempty"`
+	Tags                           string          `json:"tags,omitempty"`
+	Options                        []ProductOption `json:"options,omitempty"`
+	Variants                       []Variant       `json:"variants,omitempty"`
+	Image                          Image           `json:"image,omitempty"`
+	Images                         []Image         `json:"images,omitempty"`
+	TemplateSuffix                 string          `json:"template_suffix,omitempty"`
+	MetafieldsGlobalTitleTag       string          `json:"metafields_global_title_tag,omitempty"`
+	MetafieldsGlobalDescriptionTag string          `json:"metafields_global_description_tag,omitempty"`
+	Metafields                     []Metafield     `json:"metafields,omitempty"`
 }
 
 // The options provided by Shopify
 type ProductOption struct {
-	ID        int      `json:"id"`
-	ProductID int      `json:"product_id"`
-	Name      string   `json:"name"`
-	Position  int      `json:"position"`
-	Values    []string `json:"values"`
+	ID        int      `json:"id,omitempty"`
+	ProductID int      `json:"product_id,omitempty"`
+	Name      string   `json:"name,omitempty"`
+	Position  int      `json:"position,omitempty"`
+	Values    []string `json:"values,omitempty"`
 }
 
 // Represents the result from the products/X.json endpoint

--- a/variant.go
+++ b/variant.go
@@ -29,30 +29,30 @@ type VariantServiceOp struct {
 
 // Variant represents a Shopify variant
 type Variant struct {
-	ID                   int              `json:"id"`
-	ProductID            int              `json:"product_id"`
-	Title                string           `json:"title"`
-	Sku                  string           `json:"sku"`
-	Position             int              `json:"position"`
-	Grams                int              `json:"grams"`
-	InventoryPolicy      string           `json:"inventory_policy"`
-	Price                *decimal.Decimal `json:"price"`
-	CompareAtPrice       *decimal.Decimal `json:"compare_at_price"`
-	FulfillmentService   string           `json:"fulfillment_service"`
-	InventoryManagement  string           `json:"inventory_management"`
-	Option1              string           `json:"option1"`
-	Option2              string           `json:"option2"`
-	Option3              string           `json:"option3"`
-	CreatedAt            *time.Time       `json:"created_at"`
-	UpdatedAt            *time.Time       `json:"updated_at"`
-	Taxable              bool             `json:"taxable"`
-	Barcode              string           `json:"barcode"`
-	ImageID              int              `json:"image_id"`
-	InventoryQuantity    int              `json:"inventory_quantity"`
-	Weight               *decimal.Decimal `json:"weight"`
-	WeightUnit           string           `json:"weight_unit"`
-	OldInventoryQuantity int              `json:"old_inventory_quantity"`
-	RequireShipping      bool             `json:"requires_shipping"`
+	ID                   int              `json:"id,omitempty"`
+	ProductID            int              `json:"product_id,omitempty"`
+	Title                string           `json:"title,omitempty"`
+	Sku                  string           `json:"sku,omitempty"`
+	Position             int              `json:"position,omitempty"`
+	Grams                int              `json:"grams,omitempty"`
+	InventoryPolicy      string           `json:"inventory_policy,omitempty"`
+	Price                *decimal.Decimal `json:"price,omitempty"`
+	CompareAtPrice       *decimal.Decimal `json:"compare_at_price,omitempty"`
+	FulfillmentService   string           `json:"fulfillment_service,omitempty"`
+	InventoryManagement  string           `json:"inventory_management,omitempty"`
+	Option1              string           `json:"option1,omitempty"`
+	Option2              string           `json:"option2,omitempty"`
+	Option3              string           `json:"option3,omitempty"`
+	CreatedAt            *time.Time       `json:"created_at,omitempty"`
+	UpdatedAt            *time.Time       `json:"updated_at,omitempty"`
+	Taxable              bool             `json:"taxable,omitempty"`
+	Barcode              string           `json:"barcode,omitempty"`
+	ImageID              int              `json:"image_id,omitempty"`
+	InventoryQuantity    int              `json:"inventory_quantity,omitempty"`
+	Weight               *decimal.Decimal `json:"weight,omitempty"`
+	WeightUnit           string           `json:"weight_unit,omitempty"`
+	OldInventoryQuantity int              `json:"old_inventory_quantity,omitempty"`
+	RequireShipping      bool             `json:"requires_shipping,omitempty"`
 }
 
 // VariantResource represents the result from the variants/X.json endpoint


### PR DESCRIPTION
* Sets fields for Customer, Metafield, Product, and Variant to `omitempty` since these can accept minimal information when submitted to Shopify