### PR TITLE
Add omitempty to CustomerAddress id fields

### DIFF
--- a/customer_address.go
+++ b/customer_address.go
@@ -2,8 +2,8 @@ package goshopify
 
 // CustomerAddress represents a Shopify customer address
 type CustomerAddress struct {
-	ID           int    `json:"id"`
-	CustomerID   int    `json:"customer_id"`
+	ID           int    `json:"id,omitempty"`
+	CustomerID   int    `json:"customer_id,omitempty"`
 	FirstName    string `json:"first_name"`
 	LastName     string `json:"last_name"`
 	Company      string `json:"company"`


### PR DESCRIPTION
Noticed an issue today while trying to create a Customer with an Address in it. Shopify was returning 404's when the CustomerAddress.id field was included even though it was default valued. This fixed it for me, hope it helps others too!